### PR TITLE
Fixed attempt to include empty file breaking execution

### DIFF
--- a/simplerr.lua
+++ b/simplerr.lua
@@ -447,6 +447,11 @@ function runFile(path)
     -- Catch syntax errors with CompileString
     local err = CompileString(contents, path, false)
 
+	-- CompileString returns the following string whenever a file is empty: Invalid script - or too short.
+	--		It also prints: Not running script <path> - it's too short.
+	-- If so, do nothing.
+	if err == "Invalid script - or too short." then return true end	
+	
     -- No syntax errors, check for immediate runtime errors using CompileFile
     -- Using the function CompileString returned leads to relative path trouble
     if isfunction(err) then return safeCall(CompileFile(path), path) end


### PR DESCRIPTION
##### Print

`Not running script <path> - it's too short.`
##### Error

`[ERROR] gamemodes/darkrp/gamemode/libraries/simplerr.lua:387: bad
argument #1 to 'find' (string expected, got nil)
1. find - [C]:-1
2. translateMsg - gamemodes/darkrp/gamemode/libraries/simplerr.lua:387
3. translateError - gamemodes/darkrp/gamemode/libraries/simplerr.lua:407
4. unknown - gamemodes/darkrp/gamemode/libraries/simplerr.lua:456
5. doInclude - gamemodes/darkrp/gamemode/libraries/fn.lua:82
6. loadModules -
gamemodes/darkrp/gamemode/libraries/modificationloader.lua:84
7. Call - gamemodes/darkrp/gamemode/libraries/modificationloader.lua:141
8. unknown - gamemodes/darkrp/gamemode/init.lua:81`
#### Steps to reproduce
1. Create an empty server or shared file in a darkrpmodification module folder.
2. Run a game.
3. Search for the Print in the console.
4. Search for the Error in console (immediately under the Print).

CompileString returns `"Invalid script - or too short."` in this situation (tested with `print(err)`).
