### PR TITLE
Improved simplerr.SafeCall stack trace accuracy

### DIFF
--- a/simplerr.lua
+++ b/simplerr.lua
@@ -6,13 +6,14 @@ local file = file
 local hook = hook
 local include = include
 local isfunction = isfunction
+local isstring = isstring
 local math = math
 local os = os
-local pcall = pcall
 local string = string
 local table = table
 local tonumber = tonumber
 local unpack = unpack
+local xpcall = xpcall
 
 -- Template for syntax errors
 -- The [ERROR] start of it cannot be removed, because that would make the
@@ -409,28 +410,40 @@ end
 
 -- Call a function and catch immediate runtime errors
 function safeCall(f, ...)
-    local res = {pcall(f, ...)}
-    local succ, err = res[1], res[2]
+    local function errorHandler(err, func)
+        local debugInfo = debug.getinfo(func or 3)
+        local path = debugInfo.short_src
+
+        -- Investigate the stack. Not using path in match because calls to error can give a different path
+        local line = string.match(err, ".*:([0-9-]+)")
+        local stack = string.format("\t1. %s on line %s\n", path, line) .. getStack(func and 3 or 4, 2) -- add called func to stack
+
+        -- Line and source info aren't always in the error
+        if not line then
+            line = debugInfo.currentline
+            err = string.format("%s:%s: %s", path, line, err)
+        end
+
+        return {err, path, stack}
+    end
+
+    -- Use xpcall so fetching of debug info is in the stack of the error rather than after it is unwound
+    local res = {xpcall(f, errorHandler, ...)}
+
+    local succ, errInfo = res[1], res[2]
 
     if succ then return unpack(res) end
 
-    local info = debug.getinfo(f)
-    local path = info.short_src
-
-    -- Investigate the stack. Not using path in match because calls to error can give a different path
-    local line = string.match(err, ".*:([0-9-]+)")
-    local stack = string.format("\t1. %s on line %s\n", path, line) .. getStack(2, 2) -- add called func to stack
-
-    -- Line and source info aren't always in the error
-    if not line then
-        line = info.currentline
-        err = string.format("%s:%s: %s", path, line, err)
-    end
+    -- This will only happen if the error is "not enough memory" or "error in error handling".
+    -- The former tends to crash the game and the latter will mean it'll probably error in the next line.
+    -- But we will try anyway.
+    -- Note: stack trace will be less accurate.
+    if isstring(errInfo) then errInfo = errorHandler(errInfo, f) end
 
     -- Skip translation if the error is already a simplerr error
     -- This prevents nested simplerr errors when runError is called by a file loaded by runFile
-    local mustTranslate = not string.find(err, "------- End of Simplerr error -------")
-    return false, mustTranslate and translateError(path, err, runErrTranslation, runErrs, stack) or err
+    local mustTranslate = not string.find(errInfo[1], "------- End of Simplerr error -------")
+    return false, mustTranslate and translateError(errInfo[2], errInfo[1], runErrTranslation, runErrs, errInfo[3]) or errInfo[1]
 end
 
 -- Run a file or explain its syntax errors in layman's terms
@@ -447,11 +460,11 @@ function runFile(path)
     -- Catch syntax errors with CompileString
     local err = CompileString(contents, path, false)
 
-	-- CompileString returns the following string whenever a file is empty: Invalid script - or too short.
-	--		It also prints: Not running script <path> - it's too short.
-	-- If so, do nothing.
-	if err == "Invalid script - or too short." then return true end	
-	
+    -- CompileString returns the following string whenever a file is empty: Invalid script - or too short.
+    --		It also prints: Not running script <path> - it's too short.
+    -- If so, do nothing.
+    if err == "Invalid script - or too short." then return true end
+
     -- No syntax errors, check for immediate runtime errors using CompileFile
     -- Using the function CompileString returned leads to relative path trouble
     if isfunction(err) then return safeCall(CompileFile(path), path) end


### PR DESCRIPTION
Before it took the stack from the passed function's declaration. If the function called had errored way up higher in the stack, we would've not known about it under the previous implementation. This changes the stack fetching to inside an error handler using `xpcall`. The stack has not unwound at this point so the stack traces are more meaningful.

This has a slight downside of `xpcall` and `simplerr.SafeCall` now being included in the stack trace but it's in trade for a more useful stack trace. I don't think there's a way of reliably skipping/stopping the stack trace at `xpcall` (bearing in mind the function passed in can be calling it too). Personally, I don't think it matters too much but the previous impementation deliberately skipped `simplerr.SafeCall`.
